### PR TITLE
Use https to access ptp-splash-page submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "splash"]
 	path = splash
-	url = git@github.com:personaltelco/ptp-splash-page.git
+	url = https://github.com/personaltelco/ptp-splash-page.git


### PR DESCRIPTION
This change allows anonymous users to follow the build instructions. Discussed and tested at the October 2014 HackNight.
