### PR TITLE
Fail when device is not recognized

### DIFF
--- a/FOOCAB.pl
+++ b/FOOCAB.pl
@@ -210,6 +210,8 @@ if ( $device eq "DIR860L" || $device eq "ERX" || $device eq "WDR3600" || $device
 		$pubifaces = "lan0";
 		$privifaces = "lan1";
 	}
+} else {
+	die "Missing or unknown device: " . $device;
 }
 
 print SED "s|PTP_WANIFACE_PTP|$waniface|g\n";


### PR DESCRIPTION
This changes `FOOCAB.pl` to die when $device is missing or unknown. Without this, the configurator will happily generate a files tree populated with blank or invalid values when an unknown device code is provided.

Tested with an invalid device: https://jenkins.quinn.tk/job/cwnmyr-build/50/consoleText
And with a valid device: https://jenkins.quinn.tk/job/cwnmyr-build/51/consoleText
